### PR TITLE
Remove Keycloak health checks and dependencies from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
     depends_on:
       magjob.database:
         condition: service_healthy
-      keycloak:
-        condition: service_healthy
       
 
   # chat:
@@ -96,12 +94,6 @@ services:
     depends_on:
       keycloak.database:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
 
   # Databases
   keycloak.database:


### PR DESCRIPTION
- Deleted health check configuration for the Keycloak service.
- Removed Keycloak service dependency conditions to streamline service management.

These changes simplify the docker-compose setup by eliminating unnecessary health checks and dependencies.